### PR TITLE
Restrict common forward ports if already in use.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ depth JSON object containing the following keys,
   * SelfUpdatePath: Path to check for updated binaries. If present, the substring `$platform` is replaced with the runtime value of `runtime.GOOS+"-"+runtime.GOARCH`, for example `linux-amd64`. Similarly, the substring `$argv0` is replaced with the basename of the path returned by [os.Executable()](https://pkg.go.dev/os#Executable). SelfUpdatePath can be an S3 URL.
   * PortBase: Integer value added to device port offset to calculate actual port number for device connections.
   * CommonForwards: Common `-L` and `-R` ssh forwarding specifications.
+  * SpecialPort: If the specified `localhost:port` is active (tested by connecting to it), CommonForwards will be ignored. The intent is to avoid conflicts between services running on localhost and remote hosts.
 
 #### Device database
 

--- a/config.go
+++ b/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	SelfUpdatePath string
 	PortOffset     int
 	CommonForwards string
-	SpecialPort    string	// Don't use CommonForwards if this port is in use.
+	SpecialPort    string
 	Verbose        bool
 	SshOptionList  []string
 }

--- a/config.go
+++ b/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	SelfUpdatePath string
 	PortOffset     int
 	CommonForwards string
+	SpecialPort    string	// Don't use CommonForwards if this port is in use.
 	Verbose        bool
 	SshOptionList  []string
 }


### PR DESCRIPTION
https://vistapath.atlassian.net/browse/VUS1-2647

But try to forward VNC regardless.

See instructions in tandem remote-access PR.