### PR TITLE
Updates.

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,7 +19,6 @@ type Config struct {
 	DevicesPath    string
 	TunnelKeyPath  string
 	TunnelNameAddr string
-	DeviceNameAddr string
 	SelfUpdatePath string
 	PortOffset     int
 	CommonForwards string


### PR DESCRIPTION
* Revert to UserKnownHostsFile=/dev/null instead of UpdateHostKeys=no, which did not work as expected.
* Parse "user" field from inventory, and use "@localhost". No longer need "DeviceNameAddr" in config.

To test:
Check out the PR branch.
Copy config files for testing,
```
cp ../remote-access/config.json.vpb config.json
cp ../hardware-inventory/sentinel/sentinel-touchscreen-inventory.json devices.json
```

Build and test,
```
go build
./rdevcon
```